### PR TITLE
Refactor cli flags and config for validate command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ verify: all oci-export docker-export test
  	# Verify util signature, not actually perform rule validation
 	# Use remote ruleset
 	@echo "\n$(BLUE)$(DELIM) Verifying local ruleset $(DELIM)$(RESET)"
-	./build/whale-watcher validate $$(pwd)/testdata/verify_ruleset.yaml $$(pwd)/Dockerfile "./out/out.tar" "./out/out_docker.tar"
+	./build/whale-watcher validate $$(pwd)/testdata/verify_ruleset.yaml 
 
 .PHONY: docker-verify
 docker-verify: docker

--- a/cmd/whale-watcher/whale-watcher.go
+++ b/cmd/whale-watcher/whale-watcher.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/coffeemakingtoaster/whale-watcher/pkg/config"
+	"github.com/coffeemakingtoaster/whale-watcher/pkg/consts"
 	"github.com/coffeemakingtoaster/whale-watcher/pkg/docs"
 	"github.com/coffeemakingtoaster/whale-watcher/pkg/validator"
 	"github.com/rs/zerolog"
@@ -17,8 +18,6 @@ import (
 
 var cfg config.Config
 var cfgFile string
-
-var envPrefix = "WHALE_WATCHER_"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -102,10 +101,10 @@ func main() {
 	// Add flag/env for config file itself
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Path to config file (default: ./config.yaml)")
 	_ = viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
-	_ = viper.BindEnv("config", fmt.Sprintf("%sCONFIG_PATH", envPrefix))
+	_ = viper.BindEnv("config", fmt.Sprintf("%sCONFIG_PATH", consts.ENV_PREFIX))
 
 	// Dynamically add flags/envs for all config fields
-	if err := config.AddConfigFlagsWithGroups(rootCmd, "", &cfg, envPrefix); err != nil {
+	if err := config.AddConfigFlagsWithGroups(rootCmd, "", &cfg, ""); err != nil {
 		panic(fmt.Sprintf("failed to add config flags: %v", err))
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/coffeemakingtoaster/whale-watcher/pkg/consts"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -13,6 +14,9 @@ import (
 // AddConfigFlagsWithGroups registers flags for each nested struct
 // as a separate flag group, and binds both Viper + environment variables.
 func AddConfigFlagsWithGroups(cmd *cobra.Command, prefix string, val any, envPrefix string) error {
+	if len(envPrefix) == 0 {
+		envPrefix = consts.ENV_PREFIX
+	}
 	v := reflect.ValueOf(val)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
@@ -24,6 +28,12 @@ func AddConfigFlagsWithGroups(cmd *cobra.Command, prefix string, val any, envPre
 		fieldVal := v.Field(i)
 
 		if !fieldVal.CanInterface() {
+			continue
+		}
+
+		relevantTo := field.Tag.Get("relevant_to")
+
+		if !isRelevant(cmd, relevantTo) {
 			continue
 		}
 
@@ -157,4 +167,15 @@ func AllowsTarget(target string) bool {
 
 func ShouldInteractWithVSC() bool {
 	return ValidateGitea() == nil || ValidateGithub() == nil
+}
+
+func isRelevant(cmd *cobra.Command, relevantTo string) bool {
+	if len(relevantTo) == 0 {
+		return true
+	}
+	// global command
+	if len(cmd.CommandPath()) == 0 {
+		return false
+	}
+	return strings.HasSuffix(relevantTo, cmd.CommandPath()) || strings.Contains(relevantTo, fmt.Sprintf("%s,", cmd.CommandPath()))
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -7,13 +7,13 @@ import (
 )
 
 type Config struct {
-	Github     GithubConfig `mapstructure:"github" envPrefix:"GITHUB_" group:"Github Config"`
-	Gitea      GiteaConfig  `mapstructure:"gitea" envPrefix:"GITEA_" group:"Gitea Config"`
-	Target     TargetConfig `mapstructure:"target" envPrefix:"TARGET_" group:"Target Config"`
-	TargetList string       `mapstructure:"target_list" env:"TARGET_LIST" desc:"List all allowed targets"`
+	Github     GithubConfig `mapstructure:"github" envPrefix:"GITHUB_" group:"Github Config" relevant_to:"validate"`
+	Gitea      GiteaConfig  `mapstructure:"gitea" envPrefix:"GITEA_" group:"Gitea Config" relevant_to:"validate"`
+	Target     TargetConfig `mapstructure:"target" envPrefix:"TARGET_" group:"Target Config" relevant_to:"validate"`
+	TargetList string       `mapstructure:"target_list" env:"TARGET_LIST" desc:"List all allowed targets" relevant_to:"validate"`
 	LogLevel   int          `mapstructure:"log_level" env:"LOG_LEVEL" desc:"Set log level (1-5)"`
-	DocsURL    string       `mapstructure:"docs_url" env:"DOCS_URL" desc:"Url pointing to active deployment of policy set documentation"`
-	NoFix      bool         `mapstructure:"no_fix" env:"NO_FIX" desc:"Disable the fixing functionality for detected violations"`
+	DocsURL    string       `mapstructure:"docs_url" env:"DOCS_URL" desc:"Url pointing to active deployment of policy set documentation" relevant_to:"validate"`
+	NoFix      bool         `mapstructure:"no_fix" env:"NO_FIX" desc:"Disable the fixing functionality for detected violations" relevant_to:"validate"`
 }
 
 type GithubConfig struct {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -6,6 +6,26 @@ import (
 	"github.com/spf13/viper"
 )
 
+type Config struct {
+	Github     GithubConfig `mapstructure:"github" envPrefix:"GITHUB_" group:"Github Config"`
+	Gitea      GiteaConfig  `mapstructure:"gitea" envPrefix:"GITEA_" group:"Gitea Config"`
+	Target     TargetConfig `mapstructure:"target" envPrefix:"TARGET_" group:"Target Config"`
+	TargetList string       `mapstructure:"target_list" env:"TARGET_LIST" desc:"List all allowed targets"`
+	LogLevel   int          `mapstructure:"log_level" env:"LOG_LEVEL" desc:"Set log level (1-5)"`
+	DocsURL    string       `mapstructure:"docs_url" env:"DOCS_URL" desc:"Url pointing to active deployment of policy set documentation"`
+	NoFix      bool         `mapstructure:"no_fix" env:"NO_FIX" desc:"Disable the fixing functionality for detected violations"`
+}
+
+type GithubConfig struct {
+	PAT      string `mapstructure:"pat" env:"PAT" desc:"Personal access token of account used for creating pr and pushing changes"`
+	Username string `mapstructure:"username" env:"USER_NAME" desc:"Username of account used for creating pr and pushing changes"`
+}
+type GiteaConfig struct {
+	Username    string `mapstructure:"username" env:"USER_NAME" desc:"Username of account used for creating pr and pushing changes"`
+	Password    string `mapstructure:"password" env:"PASSWORD" desc:"Password of account used for creating pr and pushing changes"`
+	InstanceUrl string `mapstructure:"instance_url" env:"INSTANCE_URL" desc:"URL of the gitea instance"`
+}
+
 type TargetConfig struct {
 	RepositoryURL  string `mapstructure:"repository" env:"REPOSITORY_URL" desc:"Specify a remote repository. This can be empty for local."`
 	DockerfilePath string `mapstructure:"dockerfile" env:"DOCKERFILE" desc:"Specify the dockerfile path. This is either a local path or the location of the Dockerfile in the specified repository"`
@@ -14,11 +34,6 @@ type TargetConfig struct {
 	OciPath        string `mapstructure:"ocipath" env:"OCI_PATH" desc:"Specify the location of the oci tar file. Not needed if image is pulled from registry"`
 	DockerPath     string `mapstructure:"dockerpath" env:"DOCKER_PATH" desc:"Specify the location of the docker tar file. Not needed if image is pulled from registry"`
 	Insecure       bool   `mapstructure:"insecure" env:"INSECURE" desc:"Specify whether the image parsing should be done unsafe (i.e. use http instead of https to communicate with registry)"`
-}
-
-type GithubConfig struct {
-	PAT      string `mapstructure:"pat" env:"PAT" desc:"Personal access token of account used for creating pr and pushing changes"`
-	Username string `mapstructure:"username" env:"USER_NAME" desc:"Username of account used for creating pr and pushing changes"`
 }
 
 func ValidateGithub() error {
@@ -35,12 +50,6 @@ func ValidateGithub() error {
 	return nil
 }
 
-type GiteaConfig struct {
-	Username    string `mapstructure:"username" env:"USER_NAME" desc:"Username of account used for creating pr and pushing changes"`
-	Password    string `mapstructure:"password" env:"PASSWORD" desc:"Password of account used for creating pr and pushing changes"`
-	InstanceUrl string `mapstructure:"instance_url" env:"INSTANCE_URL" desc:"URL of the gitea instance"`
-}
-
 func ValidateGitea() error {
 	if viper.GetString("gitea.password") == "" {
 		return errors.New("Password must be set!")
@@ -52,14 +61,4 @@ func ValidateGitea() error {
 		return errors.New("Instanceurl must be set!")
 	}
 	return nil
-}
-
-type Config struct {
-	Github     GithubConfig `mapstructure:"github" envPrefix:"GITHUB_" group:"Github Config"`
-	Gitea      GiteaConfig  `mapstructure:"gitea" envPrefix:"GITEA_" group:"Gitea Config"`
-	Target     TargetConfig `mapstructure:"target" envPrefix:"TARGET_" group:"Target Config"`
-	TargetList string       `mapstructure:"target_list" env:"TARGET_LIST" desc:"List all allowed targets"`
-	LogLevel   int          `mapstructure:"log_level" env:"LOG_LEVEL" desc:"Set log level (1-5)"`
-	DocsURL    string       `mapstructure:"docs_url" env:"DOCS_URL" desc:"Url pointing to active deployment of policy set documentation"`
-	NoFix      bool         `mapstructure:"no_fix" env:"NO_FIX" desc:"Disable the fixing functionality for detected violations"`
 }

--- a/pkg/consts/const.go
+++ b/pkg/consts/const.go
@@ -1,0 +1,3 @@
+package consts
+
+var ENV_PREFIX = "WHALE_WATCHER_"

--- a/pkg/validator/command.go
+++ b/pkg/validator/command.go
@@ -1,9 +1,9 @@
 package validator
 
 import (
+	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/coffeemakingtoaster/whale-watcher/pkg/adapters"
 	"github.com/coffeemakingtoaster/whale-watcher/pkg/config"
@@ -29,28 +29,28 @@ func buildContext(input []string) *ValidateContext {
 
 	return &ValidateContext{
 		RuleSetEntrypoint: input[0],
-		DockerFilePath:    input[1],
-		OCITarballPath:    input[2],
-		DockerTarballPath: input[3],
+		DockerFilePath:    viper.GetString("target.dockerfile"),
+		OCITarballPath:    viper.GetString("target.ocipath"),
+		DockerTarballPath: viper.GetString("target.dockerpath"),
 	}
 }
 
 func NewCommand() *cobra.Command {
 
 	var cmd = &cobra.Command{
-		Use:   "validate [flags] <policyset> <dockerfilepath> [ocitarpath] [dockertarpath]",
-		Short: "Validate the given inputs based on the policy set",
-		Long: `Given a policy sets and input files, validate each policy. 
+		Use:   "validate [flags] <policyset>",
+		Short: "Validate the given inputs based on the policy set", Long: `Given a policy sets and input files, validate each policy. 
 
-Expected arguments:  <policy set location> <Dockerfile location> [<oci tar location>] [<docker tar location>]
+Expected arguments:  <policy set location> 
 		`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 2 {
-				return fmt.Errorf("Validate needs at least a set policy set and Dockerfile (Got: '%s')", strings.Join(args, " "))
+			if len(args) > 1 {
+				return errors.New("Validate only accepts the ruleset location as an input")
 			}
-			if len(args) > 4 {
-				return fmt.Errorf("Validate only accepts a maximum 4 arguments (policy set, Dockerfile, oci tar, docker tar) (Got: '%s')", strings.Join(args, " "))
+			if len(args) == 0 {
+				return errors.New("Validate requires the ruleset location as an input")
 			}
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/validator/command.go
+++ b/pkg/validator/command.go
@@ -78,6 +78,8 @@ Expected arguments:  <policy set location>
 			return nil
 		},
 	}
+	var cfg config.Config
+	config.AddConfigFlagsWithGroups(cmd, "", &cfg, "")
 	return cmd
 }
 


### PR DESCRIPTION
# Changes:
- [x] Remove the resource paths as arguments, they are already present in the config
- [x] Update the cli flags present globally, they are not needed for the other commands, so why have them


Closes #18 